### PR TITLE
ci: pin all GitHub Actions to latest SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Bump Version
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: minor
           custom_release_rules: bug:patch:Fixes,chore:patch:Chores,docs:patch:Documentation,feat:minor:Features,refactor:minor:Refactors,test:patch:Tests,ci:patch:Development,dev:patch:Development
       - name: Create Release
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: ${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/semantic-check.yml
+++ b/.github/workflows/semantic-check.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
-      - uses: amannn/action-semantic-pull-request@v5.2.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         name: Check PR for Semantic Commit Message
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       - name: Terraform Setup
         run:  terraform init
       - name: Terraform Validate
         run:  terraform validate
       - name: Lint Terraform
-        uses: reviewdog/action-tflint@master
+        uses: reviewdog/action-tflint@54a5e5aed57dcfbb4662ec548de876df33d6288d # v1.25.0
         with:
           github_token: ${{ secrets.github_token }}
           filter_mode: "nofilter"


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to their latest commit SHAs for improved security and reproducibility.

## Changes

| Action | Previous | Updated |
|--------|----------|---------|
| `actions/checkout` | `@v3` | `@de0fac2e…` (v6.0.2) |
| `hashicorp/setup-terraform` | `@v3` | `@dfe3c3f8…` (v4.0.1) |
| `reviewdog/action-tflint` | `@master` | `@54a5e5ae…` (v1.25.0) |
| `amannn/action-semantic-pull-request` | `@v5.2.0` | `@48f25628…` (v6.1.1) |
| `mathieudutour/github-tag-action` | `@v6.1` | `@a22cf086…` (v6.2) |
| `ncipollo/release-action` | `@v1.12.0` | `@339a8189…` (v1.21.0) |

## Why

- Pinning to SHA prevents supply-chain attacks from compromised tags
- Version comments maintain readability
- All actions updated to their latest releases