### PR TITLE
fix: replace deprecated hash_key/range_key with key_schema in DynamoDB GSI

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -227,11 +227,19 @@ resource "aws_dynamodb_table" "events" {
 
   global_secondary_index {
     name            = "timesearchV2"
-    hash_key        = "CreatedAtDate"
-    range_key       = "CreatedAt"
     write_capacity  = 10
     read_capacity   = 10
     projection_type = "ALL"
+
+    key_schema {
+      attribute_name = "CreatedAtDate"
+      key_type       = "HASH"
+    }
+
+    key_schema {
+      attribute_name = "CreatedAt"
+      key_type       = "RANGE"
+    }
   }
 
   lifecycle {
@@ -274,7 +282,6 @@ resource "aws_dynamodb_table" "locks" {
   deletion_protection_enabled = var.ddb_deletion_protection_enabled
 
   hash_key = "Lock"
-
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
## Summary

Resolves #28

Migrates the `global_secondary_index` block on `aws_dynamodb_table.events` from the deprecated `hash_key`/`range_key` arguments to the new `key_schema` block format, eliminating deprecation warnings with AWS provider v6.x.

## Changes

The `timesearchV2` GSI on the events table is migrated from:

```hcl
global_secondary_index {
  name      = "timesearchV2"
  hash_key  = "CreatedAtDate"
  range_key = "CreatedAt"
  ...
}
```

To:

```hcl
global_secondary_index {
  name = "timesearchV2"
  ...

  key_schema {
    attribute_name = "CreatedAtDate"
    key_type       = "HASH"
  }

  key_schema {
    attribute_name = "CreatedAt"
    key_type       = "RANGE"
  }
}
```

## Notes

- The table-level `hash_key`/`range_key` arguments are **not** deprecated in AWS provider v6.x (only GSI-level ones are). The deprecation warnings reported in the issue are triggered by the GSI usage.
- The `aws_dynamodb_table.events` resource has `lifecycle { ignore_changes = all }`, so this change will not cause any infrastructure modifications on existing deployments.
- Validated with `terraform validate` against AWS provider v6.46.0.