### PR TITLE
feat!: v2.0.0 — consolidate NLBs, enable TLS routing, drop node role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,94 @@
 # Terraform Module: Teleport Cluster
 
-This Terraform module deploys a Teleport cluster in high availability (HA)
-configuration. [Teleport](https://github.com/gravitational/teleport) is a modern
-zero-trust solution by Gravitational. This module has been tested with Teleport
-version v10 and v14.
+This Terraform module deploys a
+[Teleport](https://github.com/gravitational/teleport) cluster on AWS in a
+high-availability configuration. v2 of the module targets Teleport 18 and
+consolidates the network surface into a single Network Load Balancer running in
+TLS routing (multiplex) mode.
 
 ### Features
 
-- **High Availability**: Deploys Teleport in a highly available configuration to
-  ensure uninterrupted access.
-- **Managed Upgrades**: Supports controlled upgrades to new versions of
-  Teleport.
-- **Secure**: Uses AWS Key Management Service (KMS) to secure sensitive data.
-- **Scalable**: Can handle growth in your user base and infrastructure without a
-  corresponding increase in complexity.
-- **Integrated**: Works well with your existing infrastructure by following
-  CloudPosse's context and labeling patterns.
-- **Automation** to create teleport connection to resources on-demand via
-  included submodules.
+- **High availability** auth and proxy ASGs across multiple AZs.
+- **Single consolidated NLB** fronting both auth and proxy.
+- **TLS routing (multiplex)** by default — every client protocol (web UI,
+  `tsh ssh`, Kubernetes, databases, reverse tunnels) flows over the proxy's
+  `:443` listener.
+- **Defense-in-depth security groups**: the public client listener is
+  CIDR-scoped while the internal auth listener is reachable only from members of
+  the cluster security group.
+- **Optional AWS PrivateLink** so consumers in other VPCs/accounts can reach
+  Teleport without traversing the public internet.
+- **CloudPosse label/context** integration for consistent naming/tagging.
+- Companion submodules for on-demand SSH tunnels and database login.
 
 ## Usage
 
-Deploy it using the block below. For the first time deployments, it make take 10
-minutes before the web portal is available.
+The default deployment puts the consolidated NLB in private subnets
+(`nlb_internal = true`). Clients reach Teleport via PrivateLink, a VPN, Direct
+Connect, or a bastion in the same VPC. Set `nlb_internal = false` and supply
+`vpc_public_subnet_ids` to expose the cluster on the public internet.
 
 ```hcl
 module "teleport_cluster" {
   source  = "cruxstack/teleport-cluster/aws"
-  version = "x.x.x"
+  version = "2.0.0"
 
-  teleport_letsencrypt_email = "letencrypt@example.com"
-  teleport_runtime_version   = "14.3.3"
+  teleport_letsencrypt_email = "letsencrypt@example.com"
+  teleport_runtime_version   = "18.0.0"
   teleport_setup_mode        = false
   dns_parent_zone_id         = "Z0000000000000000000"
   dns_parent_zone_name       = "demo.example.com"
   vpc_id                     = "vpc-00000000000000"
-  vpc_subnet_ids             = ["subnet-00000000000000", "subnet-11111111111111111", "subnet-22222222222222222"]
-  vpc_public_subnet_ids      = ["subnet-33333333333333", "subnet-44444444444444444", "subnet-55555555555555555"]
+  vpc_private_subnet_ids     = ["subnet-...", "subnet-...", "subnet-..."]
+}
+```
+
+### Optional: PrivateLink for cross-VPC / cross-account access
+
+The internal default pairs naturally with PrivateLink so consumers in other
+VPCs/accounts can reach Teleport without traversing the public internet.
+
+```hcl
+module "teleport_cluster" {
+  # ... required inputs ...
+
+  nlb_privatelink_enabled = true
+  nlb_privatelink_config = {
+    acceptance_required = true
+    allowed_principals = [
+      "arn:aws:iam::111111111111:root",
+      "arn:aws:iam::222222222222:root",
+    ]
+  }
+}
+```
+
+Consumers in other accounts create an `aws_vpc_endpoint` against the service
+name returned in `teleport_nlb_vpce_service_name`. Only the public client
+listener (`:443`) is reachable through the endpoint service — auth (`:3025`)
+remains gated to the cluster security group and is rejected by the NLB.
+
+If `nlb_privatelink_config.private_dns_name` is set, the module also creates the
+Route 53 TXT verification record that AWS requires before consumers can enable
+`private_dns_enabled` on their VPC endpoint. The record is placed in the parent
+zone (`dns_parent_zone_id`).
+
+### Optional: internet-facing NLB
+
+Switch to a public NLB by setting `nlb_internal = false` and supplying public
+subnets. When the proxy ASG lives in the same VPC as the NLB, also set
+`nlb_auth_allowed_cidrs` to the VPC's NAT gateway EIPs so the proxy's reverse
+tunnel to auth on `:3025` is admitted (the source IP at the NLB is the NAT EIP,
+not a cluster SG member, when traffic hairpins out and back).
+
+```hcl
+module "teleport_cluster" {
+  # ... required inputs ...
+
+  nlb_internal           = false
+  vpc_public_subnet_ids  = ["subnet-...", "subnet-...", "subnet-..."]
+  nlb_allowed_cidrs      = ["0.0.0.0/0"]
+  nlb_auth_allowed_cidrs = ["203.0.113.10/32", "203.0.113.11/32"] # VPC NAT EIPs
 }
 ```
 
@@ -44,40 +96,146 @@ module "teleport_cluster" {
 
 In addition to the variables documented below, this module includes several
 other optional variables (e.g., `name`, `tags`, etc.) provided by the
-`cloudposse/label/null` module. Please refer to its [documentation](https://registry.terraform.io/modules/cloudposse/label/null/latest)
-for more details on these variables.
+`cloudposse/label/null` module. See its
+[documentation](https://registry.terraform.io/modules/cloudposse/label/null/latest)
+for details.
 
-| Name                         | Description                                                                                                       | Type           | Default | Required |
-|------------------------------|-------------------------------------------------------------------------------------------------------------------|----------------|---------|:--------:|
-| `teleport_runtime_version`   | The runtime version of Teleport.                                                                                  | `string`       | n/a     |   yes    |
-| `teleport_letsencrypt_email` | The email address to use for Let's Encrypt.                                                                       | `string`       | n/a     |   yes    |
-| `teleport_setup_mode`        | Toggle Teleport setup mode.                                                                                       | `bool`         | `true`  |    no    |
-| `teleport_experimental_mode` | Toggle Teleport experimental mode.                                                                                | `bool`         | `false` |    no    |
-| `instance_config`            | Configuration for the instances. Each type (`auth`, `node`, `proxy`) contains an object with `count` and `sizes`. | `object`       | `{}`    |    no    |
-| `artifacts_bucket_name`      | The name of the S3 bucket for artifacts.                                                                          | `string`       | `""`    |    no    |
-| `logs_bucket_name`           | The name of the S3 bucket for logs.                                                                               | `string`       | `""`    |    no    |
-| `dns_parent_zone_id`         | The ID of the parent DNS zone.                                                                                    | `string`       | n/a     |   yes    |
-| `dns_parent_zone_name`       | The name of the parent DNS zone.                                                                                  | `string`       | n/a     |   yes    |
-| `vpc_id`                     | The ID of the VPC to deploy resources into.                                                                       | `string`       | n/a     |   yes    |
-| `vpc_private_subnet_ids`     | The IDs of the private subnets in the VPC to deploy resources into.                                               | `list(string)` | n/a     |   yes    |
-| `vpc_public_subnet_ids`      | The IDs of the public subnets in the VPC to deploy resources into.                                                | `list(string)` | n/a     |   yes    |
-| `aws_region_name`            | The name of the AWS region.                                                                                       | `string`       | `""`    |    no    |
-| `aws_account_id`             | The ID of the AWS account.                                                                                        | `string`       | `""`    |    no    |
-| `aws_kv_namespace`           | The namespace or prefix for AWS SSM parameters and similar resources.                                             | `string`       | `""`    |    no    |
+| Name                          | Description                                                                                                | Type           | Default         | Required |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------- | --------------- | :------: |
+| `teleport_runtime_version`    | The runtime version of Teleport (v18 recommended).                                                         | `string`       | n/a             |   yes    |
+| `teleport_letsencrypt_email`  | The email address to use for Let's Encrypt.                                                                | `string`       | n/a             |   yes    |
+| `teleport_setup_mode`         | Toggle Teleport setup mode.                                                                                | `bool`         | `true`          |    no    |
+| `teleport_experimental_mode`  | Toggle Teleport experimental mode.                                                                         | `bool`         | `false`         |    no    |
+| `deletion_protection_enabled` | Enable deletion protection on the NLB and DynamoDB tables. `null` ⇒ follows `!teleport_experimental_mode`. | `bool`         | `null`          |    no    |
+| `instance_config`             | Configuration for the auth and proxy ASGs (`auth`, `proxy` keys with `count`, `sizes`, `spot`).            | `object`       | `{}`            |    no    |
+| `nlb_internal`                | Use an internal NLB (private subnets) instead of internet-facing (public subnets).                         | `bool`         | `true`          |    no    |
+| `nlb_allowed_cidrs`           | CIDRs allowed on the public client port (443) of the NLB.                                                  | `list(string)` | `["0.0.0.0/0"]` |    no    |
+| `nlb_auth_allowed_cidrs`      | CIDRs allowed on the auth listener (3025). Defaults to empty (cluster SG only). See bootstrap notes.       | `list(string)` | `[]`            |    no    |
+| `nlb_privatelink_enabled`     | Expose the NLB as a PrivateLink endpoint service.                                                          | `bool`         | `false`         |    no    |
+| `nlb_privatelink_config`      | PrivateLink config: `acceptance_required`, `allowed_principals`, `private_dns_name`, `supported_regions`.  | `object`       | `{}`            |    no    |
+| `artifacts_bucket_name`       | The name of the S3 bucket for artifacts.                                                                   | `string`       | `""`            |    no    |
+| `logs_bucket_name`            | The name of the S3 bucket for logs.                                                                        | `string`       | `""`            |    no    |
+| `dns_parent_zone_id`          | The ID of the parent DNS zone.                                                                             | `string`       | n/a             |   yes    |
+| `dns_parent_zone_name`        | The name of the parent DNS zone.                                                                           | `string`       | n/a             |   yes    |
+| `vpc_id`                      | The ID of the VPC to deploy resources into.                                                                | `string`       | n/a             |   yes    |
+| `vpc_private_subnet_ids`      | The IDs of the private subnets in the VPC.                                                                 | `list(string)` | n/a             |   yes    |
+| `vpc_public_subnet_ids`       | The IDs of the public subnets. Required when `nlb_internal = false`; may be empty otherwise.               | `list(string)` | `[]`            |    no    |
+| `aws_region_name`             | The name of the AWS region.                                                                                | `string`       | `""`            |    no    |
+| `aws_account_id`              | The ID of the AWS account.                                                                                 | `string`       | `""`            |    no    |
+| `aws_kv_namespace`            | The namespace or prefix for AWS SSM parameters and similar resources.                                      | `string`       | `""`            |    no    |
 
 ### Outputs
 
-| Name                    | Description                                                      |
-|-------------------------|------------------------------------------------------------------|
-| `teleport_dns_name`     | The DNS name of the Teleport service.                            |
-| `teleport_auth_config`  | The configuration details for the Teleport auth service.         |
-| `teleport_node_config`  | The configuration details for the Teleport node service.         |
-| `teleport_proxy_config` | The configuration details for the Teleport proxy service.        |
-| `security_group_id`     | The ID of the security group created for the Teleport service.   |
-| `security_group_name`   | The name of the security group created for the Teleport service. |
+| Name                             | Description                                                    |
+| -------------------------------- | -------------------------------------------------------------- |
+| `teleport_dns_name`              | The DNS name of the Teleport service.                          |
+| `teleport_auth_config`           | The Teleport auth configuration.                               |
+| `teleport_proxy_config`          | The Teleport proxy configuration.                              |
+| `teleport_nlb_dns_name`          | DNS name of the consolidated Teleport NLB.                     |
+| `teleport_nlb_arn`               | ARN of the consolidated Teleport NLB.                          |
+| `teleport_nlb_zone_id`           | Hosted zone ID of the consolidated Teleport NLB.               |
+| `teleport_nlb_security_group_id` | Dedicated NLB security group (public CIDR ingress lives here). |
+| `teleport_nlb_target_group_arns` | Map of target group ARNs (`auth_ssh`, `proxy_web`).            |
+| `teleport_nlb_vpce_service_name` | PrivateLink endpoint service name (empty when disabled).       |
+| `teleport_nlb_vpce_service_id`   | PrivateLink endpoint service ID (empty when disabled).         |
+| `teleport_nlb_vpce_service_arn`  | PrivateLink endpoint service ARN (empty when disabled).        |
+| `security_group_id`              | The ID of the cluster security group.                          |
+| `security_group_name`            | The name of the cluster security group.                        |
+
+## Network design (v2)
+
+The consolidated NLB has exactly two listeners:
+
+| Listener | Backend target      | Who can reach it                                                                 |
+| -------- | ------------------- | -------------------------------------------------------------------------------- |
+| `:443`   | proxy ASG → `:3080` | `nlb_allowed_cidrs` **plus** any member of the cluster security group.           |
+| `:3025`  | auth ASG → `:3025`  | Members of the cluster security group **only**. Never reachable from the public. |
+
+This is enforced by attaching **two** security groups to the NLB:
+
+1. A dedicated NLB security group (managed by this module) that holds the public
+   CIDR ingress rules for `:443` only.
+2. The shared cluster security group, of which both auth and proxy instances are
+   members. Its existing self-ingress rule grants cluster members and the NLB
+   ENIs full reachability to each other on every port — which is what covers the
+   proxy ⇄ auth control channel on `:3025`.
+
+`enforce_security_group_inbound_rules_on_private_link_traffic = on` means the
+same rules also apply to PrivateLink consumer traffic, so endpoint ENIs (which
+are not members of the cluster SG) can never reach `:3025`.
+
+The `proxy_web` target group has `proxy_protocol_v2 = true`, and the Teleport
+proxy config carries `proxy_service.proxy_protocol = "on"`. The two together
+preserve the real client IP at L7 (for the audit log) while the L3 source on the
+wire is the NLB ENI — which is exactly what makes the security-group based
+design work.
+
+### Reaching the cluster
+
+The default (`nlb_internal = true`) puts the NLB in the private subnets.
+Same-VPC proxy ⇄ auth traffic stays in-VPC: the proxy resolves the NLB DNS to
+private ENI IPs and the cluster SG admits the connection on `:3025`. Public
+clients reach the cluster via one of:
+
+- **PrivateLink.** Set `nlb_privatelink_enabled = true` and have consumers
+  create endpoints against the resulting endpoint service.
+- **VPN / Direct Connect.** Anything that puts the client in the cluster VPC's
+  routable address space resolves the NLB DNS internally.
+- **In-VPC bastion or operator workstation.** Same constraint as VPN: the
+  resolver needs to be inside the VPC.
+
+To expose Teleport on the public internet, set `nlb_internal = false` and supply
+`vpc_public_subnet_ids`. When the proxy ASG lives in the same VPC and the NLB is
+internet-facing, the proxy resolves the NLB's public DNS to its public ENI IPs
+and the traffic egresses via the VPC NAT gateway. At the NLB, the apparent
+source is the NAT EIP — not a member of the cluster security group — so the
+SG-only `:3025` rule rejects the connection and the proxy never registers with
+auth. Two ways to resolve it, in order of preference:
+
+1. **Use `nlb_internal = false` + `nlb_auth_allowed_cidrs`.** Set the variable
+   to the VPC NAT gateway EIPs so the auth listener accepts traffic arriving
+   from those specific IPs. Wider scopes work but increase the public attack
+   surface on `:3025`. mTLS still gates the connection at Teleport, but
+   defense-in-depth is reduced.
+2. **Use `nlb_internal = false` + PrivateLink for in-VPC consumers.** Deploy an
+   `aws_vpc_endpoint` in the cluster VPC against the module's endpoint service
+   and point the proxy at the endpoint DNS instead of the NLB DNS. More moving
+   parts; only worth it if you have a wider PrivateLink story.
+
+## Migrating from v1.x to v2
+
+v2 is a breaking change. The major items:
+
+1. **Single consolidated NLB.** The dedicated `auth` and `proxy` NLBs and their
+   target groups/listeners are gone. AWS will replace the existing NLB(s) and
+   target groups; Route53 proxy alias records are migrated in place via
+   `moved {}` blocks and update to point at the new NLB.
+2. **TLS routing (multiplex) is mandatory.** The proxy now uses `version: v2`
+   and only opens its `web_listen_addr` (`:3080`, fronted by the NLB on `:443`).
+   The auth advertises `proxy_listener_mode: multiplex`. Both halves must agree
+   — see Teleport issue
+   [#57009](https://github.com/gravitational/teleport/issues/57009). All client
+   protocols (SSH, k8s, databases) now ride `:443`.
+3. **`node` role removed.** `module.node_servers`, the `instance_config.node`
+   key, and the `teleport_node_config` output are gone. Pre-existing node ASGs
+   are destroyed on the next `terraform apply`.
+4. **`vpc_security_group_allowed_cidrs` / `instance_config.*.allowed_cidrs`
+   removed.** Client allow-lists moved to `nlb_allowed_cidrs` on the
+   consolidated NLB.
+5. **PROXY protocol.** Connections from the NLB to the proxy carry PROXY
+   protocol v2. Anything bypassing the NLB and hitting the proxy on `:3080`
+   directly will be rejected — by design.
+6. **`nlb_internal` defaults to `true`.** v1 was implicitly internet-facing for
+   the proxy NLB. The v2 default is internal so same-VPC proxy ⇄ auth traffic
+   works without extra config. Pass `nlb_internal = false` and
+   `vpc_public_subnet_ids` to restore public exposure.
+7. **Deletion protection unified.** `ddb_deletion_protection_enabled` and
+   `nlb_deletion_protection` are removed. Use `deletion_protection_enabled`
+   (default `null` ⇒ follows `!teleport_experimental_mode`) instead.
+8. **Terraform `required_version` bumped to `>= 1.9.0`** to use cross-variable
+   references in `validation` blocks.
 
 ## Contributing
 
-We welcome contributions to this project. For information on setting up a
-development environment and how to make a contribution, see [CONTRIBUTING](./CONTRIBUTING.md)
-documentation.
+We welcome contributions. See [CONTRIBUTING](./CONTRIBUTING.md) for setup and
+contribution guidelines.

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,10 @@ locals {
   is_teleport_and_logs_bucket_same = local.artifacts_bucket_name == local.logs_bucket_name
 
   instance_config = var.instance_config
+
+  # Honour the explicit override when set; otherwise tie protection to the
+  # inverse of experimental mode so ephemeral clusters tear down cleanly.
+  deletion_protection_enabled = var.deletion_protection_enabled != null ? var.deletion_protection_enabled : !local.teleport_experimental_mode
 }
 
 data "aws_caller_identity" "current" {
@@ -50,6 +54,29 @@ resource "random_string" "teleport_cluster_random_suffix" {
   upper   = false
 }
 
+# ====================================================================== nlb ===
+
+module "teleport_nlb" {
+  source = "./modules/teleport-nlb"
+
+  nlb_internal                = var.nlb_internal
+  nlb_allowed_cidrs           = var.nlb_allowed_cidrs
+  nlb_auth_allowed_cidrs      = var.nlb_auth_allowed_cidrs
+  nlb_privatelink_enabled     = var.nlb_privatelink_enabled
+  nlb_privatelink_config      = var.nlb_privatelink_config
+  deletion_protection_enabled = local.deletion_protection_enabled
+
+  dns_parent_zone_id        = var.dns_parent_zone_id
+  dns_parent_zone_name      = var.dns_parent_zone_name
+  logs_bucket_name          = local.logs_bucket_name
+  vpc_id                    = var.vpc_id
+  vpc_private_subnet_ids    = var.vpc_private_subnet_ids
+  vpc_public_subnet_ids     = var.vpc_public_subnet_ids
+  cluster_security_group_id = module.security_group.id
+
+  context = module.teleport_cluster_label.context
+}
+
 # ================================================================== cluster ===
 
 module "auth_servers" {
@@ -64,6 +91,7 @@ module "auth_servers" {
   teleport_letsencrypt_email = local.teleport_letsencrypt_email
   teleport_node_type         = "auth"
   teleport_setup_mode        = local.teleport_setup_mode
+  teleport_public_addr       = module.teleport_nlb.teleport_dns_name
 
   teleport_bucket_name           = module.s3_bucket.bucket_id
   teleport_ddb_table_events_name = aws_dynamodb_table.events[0].name
@@ -73,17 +101,19 @@ module "auth_servers" {
 
   experimental = local.teleport_experimental_mode
 
-  dns_parent_zone_id               = var.dns_parent_zone_id
-  dns_parent_zone_name             = var.dns_parent_zone_name
-  artifacts_bucket_name            = local.artifacts_bucket_name
-  logs_bucket_name                 = local.logs_bucket_name
-  vpc_id                           = var.vpc_id
-  vpc_private_subnet_ids           = var.vpc_private_subnet_ids
-  vpc_public_subnet_ids            = var.vpc_public_subnet_ids
-  vpc_security_group_allowed_cidrs = local.instance_config.auth.allowed_cidrs
-  aws_account_id                   = local.aws_account_id
-  aws_kv_namespace                 = local.aws_kv_namespace
-  aws_region_name                  = local.aws_region_name
+  target_group_arns     = compact([module.teleport_nlb.target_group_arns.auth_ssh])
+  nlb_security_group_id = module.teleport_nlb.security_group_id
+
+  dns_parent_zone_id     = var.dns_parent_zone_id
+  dns_parent_zone_name   = var.dns_parent_zone_name
+  artifacts_bucket_name  = local.artifacts_bucket_name
+  logs_bucket_name       = local.logs_bucket_name
+  vpc_id                 = var.vpc_id
+  vpc_private_subnet_ids = var.vpc_private_subnet_ids
+  vpc_public_subnet_ids  = var.vpc_public_subnet_ids
+  aws_account_id         = local.aws_account_id
+  aws_kv_namespace       = local.aws_kv_namespace
+  aws_region_name        = local.aws_region_name
 
   context = module.teleport_cluster_label.context
 }
@@ -101,7 +131,7 @@ module "proxy_servers" {
   teleport_node_type         = "proxy"
   teleport_setup_mode        = local.teleport_setup_mode
 
-  teleport_auth_address          = module.auth_servers.lb_dns_name
+  teleport_auth_address          = module.teleport_nlb.teleport_dns_name
   teleport_bucket_name           = module.s3_bucket.bucket_id
   teleport_ddb_table_events_name = aws_dynamodb_table.events[0].name
   teleport_ddb_table_locks_name  = aws_dynamodb_table.locks[0].name
@@ -110,54 +140,19 @@ module "proxy_servers" {
 
   experimental = local.teleport_experimental_mode
 
-  dns_parent_zone_id               = var.dns_parent_zone_id
-  dns_parent_zone_name             = var.dns_parent_zone_name
-  artifacts_bucket_name            = local.artifacts_bucket_name # todo - create bucket with module
-  logs_bucket_name                 = local.logs_bucket_name
-  vpc_id                           = var.vpc_id
-  vpc_private_subnet_ids           = var.vpc_private_subnet_ids
-  vpc_public_subnet_ids            = var.vpc_public_subnet_ids
-  vpc_security_group_allowed_cidrs = local.instance_config.proxy.allowed_cidrs
-  aws_account_id                   = local.aws_account_id
-  aws_kv_namespace                 = local.aws_kv_namespace
-  aws_region_name                  = local.aws_region_name
+  target_group_arns     = compact([module.teleport_nlb.target_group_arns.proxy_web])
+  nlb_security_group_id = module.teleport_nlb.security_group_id
 
-  context = module.teleport_cluster_label.context
-}
-
-module "node_servers" {
-  source = "./modules/teleport-node"
-
-  instance_sizes = local.instance_config.node.sizes
-  instance_count = local.instance_config.node.count
-  instance_spot  = local.instance_config.node.spot
-
-  teleport_cluster_name      = local.teleport_cluster_name
-  teleport_image_id          = local.teleport_image_id
-  teleport_letsencrypt_email = local.teleport_letsencrypt_email
-  teleport_node_type         = "node"
-  teleport_setup_mode        = local.teleport_setup_mode
-
-  teleport_auth_address          = module.auth_servers.lb_dns_name
-  teleport_bucket_name           = module.s3_bucket.bucket_id
-  teleport_ddb_table_events_name = aws_dynamodb_table.events[0].name
-  teleport_ddb_table_locks_name  = aws_dynamodb_table.locks[0].name
-  teleport_ddb_table_state_name  = aws_dynamodb_table.state[0].name
-  teleport_security_group_ids    = compact([module.security_group.id])
-
-  experimental = local.teleport_experimental_mode
-
-  dns_parent_zone_id               = var.dns_parent_zone_id
-  dns_parent_zone_name             = var.dns_parent_zone_name
-  artifacts_bucket_name            = local.artifacts_bucket_name # todo - create bucket with module
-  logs_bucket_name                 = local.logs_bucket_name
-  vpc_id                           = var.vpc_id
-  vpc_private_subnet_ids           = var.vpc_private_subnet_ids
-  vpc_public_subnet_ids            = var.vpc_public_subnet_ids
-  vpc_security_group_allowed_cidrs = local.instance_config.node.allowed_cidrs
-  aws_account_id                   = local.aws_account_id
-  aws_kv_namespace                 = local.aws_kv_namespace
-  aws_region_name                  = local.aws_region_name
+  dns_parent_zone_id     = var.dns_parent_zone_id
+  dns_parent_zone_name   = var.dns_parent_zone_name
+  artifacts_bucket_name  = local.artifacts_bucket_name # todo - create bucket with module
+  logs_bucket_name       = local.logs_bucket_name
+  vpc_id                 = var.vpc_id
+  vpc_private_subnet_ids = var.vpc_private_subnet_ids
+  vpc_public_subnet_ids  = var.vpc_public_subnet_ids
+  aws_account_id         = local.aws_account_id
+  aws_kv_namespace       = local.aws_kv_namespace
+  aws_region_name        = local.aws_region_name
 
   context = module.teleport_cluster_label.context
 }
@@ -171,7 +166,7 @@ resource "aws_dynamodb_table" "state" {
 
   name                        = "${module.teleport_cluster_label.id}-state"
   billing_mode                = "PAY_PER_REQUEST"
-  deletion_protection_enabled = var.ddb_deletion_protection_enabled
+  deletion_protection_enabled = local.deletion_protection_enabled
 
   hash_key         = "HashKey"
   range_key        = "FullPath"
@@ -212,7 +207,7 @@ resource "aws_dynamodb_table" "events" {
 
   name                        = "${module.teleport_cluster_label.id}-events"
   billing_mode                = "PAY_PER_REQUEST"
-  deletion_protection_enabled = var.ddb_deletion_protection_enabled
+  deletion_protection_enabled = local.deletion_protection_enabled
 
   hash_key  = "SessionID"
   range_key = "EventIndex"
@@ -279,7 +274,7 @@ resource "aws_dynamodb_table" "locks" {
 
   name                        = "${module.teleport_cluster_label.id}-locks"
   billing_mode                = "PAY_PER_REQUEST"
-  deletion_protection_enabled = var.ddb_deletion_protection_enabled
+  deletion_protection_enabled = local.deletion_protection_enabled
 
   hash_key = "Lock"
 
@@ -455,4 +450,3 @@ data "aws_ami" "official_image" {
     values = [local.teleport_image_name]
   }
 }
-

--- a/modules/teleport-nlb/context.tf
+++ b/modules/teleport-nlb/context.tf
@@ -1,0 +1,277 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}

--- a/modules/teleport-nlb/main.tf
+++ b/modules/teleport-nlb/main.tf
@@ -1,0 +1,254 @@
+locals {
+  enabled = module.this.enabled
+
+  nlb_internal              = var.nlb_internal
+  nlb_subnet_ids            = local.nlb_internal ? var.vpc_private_subnet_ids : var.vpc_public_subnet_ids
+  nlb_privatelink_enabled   = local.enabled && var.nlb_privatelink_enabled
+  nlb_privatelink_config    = var.nlb_privatelink_config
+  nlb_allowed_cidrs         = var.nlb_allowed_cidrs
+  nlb_auth_allowed_cidrs    = var.nlb_auth_allowed_cidrs
+  cluster_security_group_id = var.cluster_security_group_id
+
+  dns_parent_zone_id   = var.dns_parent_zone_id
+  dns_parent_zone_name = var.dns_parent_zone_name
+  dns_name             = "${module.dns_label.id}.${local.dns_parent_zone_name}"
+
+  listeners = {
+    proxy_web = {
+      port           = 443
+      target_port    = 3080
+      proxy_protocol = true
+    }
+    auth_ssh = {
+      port           = 3025
+      target_port    = 3025
+      proxy_protocol = false
+    }
+  }
+
+  proxy_ingress_pairs = {
+    for cidr in local.nlb_allowed_cidrs : "proxy_web-cidr-${replace(cidr, "/[^0-9a-zA-Z]/", "-")}" => {
+      port = local.listeners.proxy_web.port
+      cidr = cidr
+    }
+  }
+
+  auth_ingress_pairs = {
+    for cidr in local.nlb_auth_allowed_cidrs : "auth_ssh-cidr-${replace(cidr, "/[^0-9a-zA-Z]/", "-")}" => {
+      port = local.listeners.auth_ssh.port
+      cidr = cidr
+    }
+  }
+}
+
+# ================================================================== labels ===
+
+module "nlb_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  id_length_limit = 32
+  label_order     = ["name", "attributes"]
+  context         = module.this.context
+}
+
+# TG names are capped at 32 chars; reserve 10 for the "-proxy-web" suffix.
+module "tg_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  id_length_limit = 22
+  label_order     = ["name", "attributes"]
+  context         = module.this.context
+}
+
+module "dns_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  label_order = ["environment", "name", "attributes"]
+  context     = module.this.context
+}
+
+# ================================================================== nlb sg ===
+
+resource "aws_security_group" "this" {
+  count = local.enabled ? 1 : 0
+
+  name        = module.nlb_label.id
+  description = "Public ingress controls for the consolidated Teleport NLB"
+  vpc_id      = var.vpc_id
+
+  tags = merge(module.this.tags, { Name = module.nlb_label.id })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "proxy_cidrs" {
+  for_each = local.enabled ? local.proxy_ingress_pairs : {}
+
+  security_group_id = aws_security_group.this[0].id
+  description       = "allow proxy_web (${each.value.port}) from ${each.value.cidr}"
+  ip_protocol       = "tcp"
+  from_port         = each.value.port
+  to_port           = each.value.port
+  cidr_ipv4         = each.value.cidr
+}
+
+# Opt-in CIDR ingress on the auth listener. Off by default so :3025 stays
+# gated to the cluster SG. Required when nlb_internal=false and same-VPC
+# proxies must reach auth through the NLB's public IPs.
+resource "aws_vpc_security_group_ingress_rule" "auth_cidrs" {
+  for_each = local.enabled ? local.auth_ingress_pairs : {}
+
+  security_group_id = aws_security_group.this[0].id
+  description       = "allow auth_ssh (${each.value.port}) from ${each.value.cidr}"
+  ip_protocol       = "tcp"
+  from_port         = each.value.port
+  to_port           = each.value.port
+  cidr_ipv4         = each.value.cidr
+}
+
+# ===================================================================== nlb ===
+
+resource "aws_lb" "this" {
+  count = local.enabled ? 1 : 0
+
+  name                                                         = module.nlb_label.id
+  internal                                                     = local.nlb_internal
+  subnets                                                      = local.nlb_subnet_ids
+  load_balancer_type                                           = "network"
+  idle_timeout                                                 = 3600
+  enable_cross_zone_load_balancing                             = true
+  enable_deletion_protection                                   = var.deletion_protection_enabled
+  enforce_security_group_inbound_rules_on_private_link_traffic = "on"
+
+  security_groups = [
+    aws_security_group.this[0].id,
+    local.cluster_security_group_id,
+  ]
+
+  access_logs {
+    bucket  = var.logs_bucket_name
+    enabled = true
+  }
+
+  tags = module.this.tags
+}
+
+# ----------------------------------------------------------- target-groups ---
+
+resource "aws_lb_target_group" "auth_ssh" {
+  count = local.enabled ? 1 : 0
+
+  name     = "${module.tg_label.id}-auth-ssh"
+  port     = local.listeners.auth_ssh.target_port
+  vpc_id   = var.vpc_id
+  protocol = "TCP"
+
+  proxy_protocol_v2 = local.listeners.auth_ssh.proxy_protocol
+
+  tags = module.this.tags
+}
+
+resource "aws_lb_target_group" "proxy_web" {
+  count = local.enabled ? 1 : 0
+
+  name     = "${module.tg_label.id}-proxy-web"
+  port     = local.listeners.proxy_web.target_port
+  vpc_id   = var.vpc_id
+  protocol = "TCP"
+
+  proxy_protocol_v2 = local.listeners.proxy_web.proxy_protocol
+
+  tags = module.this.tags
+}
+
+# --------------------------------------------------------------- listeners ---
+
+resource "aws_lb_listener" "auth_ssh" {
+  count = local.enabled ? 1 : 0
+
+  load_balancer_arn = aws_lb.this[0].arn
+  port              = local.listeners.auth_ssh.port
+  protocol          = "TCP"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.auth_ssh[0].arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "proxy_web" {
+  count = local.enabled ? 1 : 0
+
+  load_balancer_arn = aws_lb.this[0].arn
+  port              = local.listeners.proxy_web.port
+  protocol          = "TCP"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.proxy_web[0].arn
+    type             = "forward"
+  }
+}
+
+# ================================================================== route53 ===
+
+resource "aws_route53_record" "proxy" {
+  count = local.enabled ? 1 : 0
+
+  zone_id         = local.dns_parent_zone_id
+  name            = local.dns_name
+  type            = "A"
+  allow_overwrite = true
+
+  alias {
+    name                   = aws_lb.this[0].dns_name
+    zone_id                = aws_lb.this[0].zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "proxy_wildcard" {
+  count = local.enabled ? 1 : 0
+
+  zone_id         = local.dns_parent_zone_id
+  name            = "*.${local.dns_name}"
+  type            = "A"
+  allow_overwrite = true
+
+  alias {
+    name                   = aws_lb.this[0].dns_name
+    zone_id                = aws_lb.this[0].zone_id
+    evaluate_target_health = true
+  }
+}
+
+# ============================================================== privatelink ===
+
+resource "aws_vpc_endpoint_service" "this" {
+  count = local.nlb_privatelink_enabled ? 1 : 0
+
+  acceptance_required        = local.nlb_privatelink_config.acceptance_required
+  network_load_balancer_arns = [aws_lb.this[0].arn]
+  allowed_principals         = local.nlb_privatelink_config.allowed_principals
+  private_dns_name           = local.nlb_privatelink_config.private_dns_name != "" ? local.nlb_privatelink_config.private_dns_name : null
+  supported_regions          = length(local.nlb_privatelink_config.supported_regions) > 0 ? local.nlb_privatelink_config.supported_regions : null
+
+  tags = module.this.tags
+}
+
+# Verifies the endpoint service's private_dns_name with AWS so consumers can
+# create endpoints with private_dns_enabled = true. The TXT record lives in
+# dns_parent_zone_id (same zone as the proxy alias records).
+resource "aws_route53_record" "vpce_private_dns_verification" {
+  count = local.nlb_privatelink_enabled && local.nlb_privatelink_config.private_dns_name != "" ? 1 : 0
+
+  zone_id = local.dns_parent_zone_id
+  name    = "${tolist(aws_vpc_endpoint_service.this[0].private_dns_name_configuration)[0].name}.${local.nlb_privatelink_config.private_dns_name}"
+  type    = tolist(aws_vpc_endpoint_service.this[0].private_dns_name_configuration)[0].type
+  ttl     = 1800
+  records = [tolist(aws_vpc_endpoint_service.this[0].private_dns_name_configuration)[0].value]
+}

--- a/modules/teleport-nlb/outputs.tf
+++ b/modules/teleport-nlb/outputs.tf
@@ -1,0 +1,47 @@
+output "nlb_dns_name" {
+  value       = local.enabled ? aws_lb.this[0].dns_name : ""
+  description = "DNS name of the consolidated Teleport NLB."
+}
+
+output "nlb_arn" {
+  value       = local.enabled ? aws_lb.this[0].arn : ""
+  description = "ARN of the consolidated Teleport NLB."
+}
+
+output "nlb_zone_id" {
+  value       = local.enabled ? aws_lb.this[0].zone_id : ""
+  description = "Hosted zone ID of the consolidated Teleport NLB."
+}
+
+output "security_group_id" {
+  value       = local.enabled ? aws_security_group.this[0].id : ""
+  description = "Security group attached to the consolidated Teleport NLB."
+}
+
+output "target_group_arns" {
+  value = {
+    auth_ssh  = local.enabled ? aws_lb_target_group.auth_ssh[0].arn : ""
+    proxy_web = local.enabled ? aws_lb_target_group.proxy_web[0].arn : ""
+  }
+  description = "Target group ARNs keyed by listener name."
+}
+
+output "teleport_dns_name" {
+  value       = local.enabled ? local.dns_name : ""
+  description = "Public DNS name (FQDN) the Teleport proxy is reachable at."
+}
+
+output "vpce_service_name" {
+  value       = local.nlb_privatelink_enabled ? aws_vpc_endpoint_service.this[0].service_name : ""
+  description = "PrivateLink service name (consumers use this when creating a VPC endpoint). Empty when PrivateLink is disabled."
+}
+
+output "vpce_service_id" {
+  value       = local.nlb_privatelink_enabled ? aws_vpc_endpoint_service.this[0].id : ""
+  description = "PrivateLink endpoint service ID. Empty when PrivateLink is disabled."
+}
+
+output "vpce_service_arn" {
+  value       = local.nlb_privatelink_enabled ? aws_vpc_endpoint_service.this[0].arn : ""
+  description = "PrivateLink endpoint service ARN. Empty when PrivateLink is disabled."
+}

--- a/modules/teleport-nlb/variables.tf
+++ b/modules/teleport-nlb/variables.tf
@@ -1,0 +1,87 @@
+# =================================================================== nlb ===
+
+variable "nlb_internal" {
+  type        = bool
+  description = "Whether the consolidated NLB should be internal (true, the default) or internet-facing (false). Internal places the NLB in `vpc_private_subnet_ids` so same-VPC consumers resolve it to private ENI IPs."
+  default     = true
+}
+
+variable "nlb_allowed_cidrs" {
+  type        = list(string)
+  description = "CIDRs allowed to reach the consolidated NLB on the public client port (443)."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "nlb_auth_allowed_cidrs" {
+  type        = list(string)
+  description = "CIDRs allowed to reach the consolidated NLB on the auth listener (3025). Defaults to empty — :3025 is gated to members of the cluster security group only. Set to e.g. the VPC's NAT gateway EIPs when `nlb_internal = false` and same-VPC proxies must reach auth through the NLB's public IPs (the source IP at the NLB then no longer matches the cluster SG)."
+  default     = []
+}
+
+variable "nlb_privatelink_enabled" {
+  type        = bool
+  description = "When true, expose the NLB as an AWS PrivateLink (VPC Endpoint Service) so consumers in other VPCs/accounts can reach Teleport over the AWS network. Only the client port (443) is reachable through the endpoint service; the internal auth listener (3025) remains SG-gated and blocked at the NLB."
+  default     = false
+}
+
+variable "nlb_privatelink_config" {
+  type = object({
+    acceptance_required = optional(bool, true)
+    allowed_principals  = optional(list(string), [])
+    private_dns_name    = optional(string, "")
+    supported_regions   = optional(list(string), [])
+  })
+  description = "Configuration applied to the PrivateLink endpoint service when `nlb_privatelink_enabled` is true."
+  default     = {}
+}
+
+# ----------------------------------------------------------------- network ---
+
+variable "vpc_id" {
+  type        = string
+  description = "ID of the VPC the NLB will be attached to."
+}
+
+variable "vpc_private_subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs used when `nlb_internal` is true."
+  default     = []
+}
+
+variable "vpc_public_subnet_ids" {
+  type        = list(string)
+  description = "Public subnet IDs used when `nlb_internal` is false."
+  default     = []
+}
+
+variable "cluster_security_group_id" {
+  type        = string
+  description = "Security group ID shared by the Teleport auth and proxy instances. The NLB is attached to this group so its self-ingress rule grants cluster members (and the NLB ENIs themselves) full intra-cluster reachability — including the auth listener on 3025."
+}
+
+# --------------------------------------------------------------------- dns ---
+
+variable "dns_parent_zone_id" {
+  type        = string
+  description = "ID of the Route53 hosted zone that will hold the proxy alias records."
+}
+
+variable "dns_parent_zone_name" {
+  type        = string
+  description = "Name of the Route53 parent hosted zone (used to build the FQDN)."
+}
+
+# ----------------------------------------------------------------- buckets ---
+
+variable "logs_bucket_name" {
+  type        = string
+  description = "S3 bucket used to store NLB access logs."
+}
+
+# --------------------------------------------------------------- behaviour ---
+
+variable "deletion_protection_enabled" {
+  type        = bool
+  description = "Enable deletion protection on the consolidated NLB."
+  default     = true
+}

--- a/modules/teleport-node/main.tf
+++ b/modules/teleport-node/main.tf
@@ -6,6 +6,7 @@ locals {
   teleport_letsencrypt_email = var.teleport_letsencrypt_email
   teleport_node_type         = var.teleport_node_type
   teleport_setup_enabled     = module.this.enabled && var.teleport_setup_mode
+  teleport_public_addr       = var.teleport_public_addr
 
   teleport_ddb_table_events_name = var.teleport_ddb_table_events_name
   teleport_ddb_table_locks_name  = var.teleport_ddb_table_locks_name
@@ -34,6 +35,9 @@ locals {
   vpc_private_subnet_ids   = var.vpc_private_subnet_ids
   vpc_public_subnet_ids    = var.vpc_public_subnet_ids
 
+  nlb_security_group_id = var.nlb_security_group_id
+  target_group_arns     = var.target_group_arns
+
   iam_role_attached_policy_arns = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
   iam_role_attached_policies = flatten([
     module.this.enabled ? [
@@ -50,12 +54,6 @@ locals {
       {
         name   = "teleport-auth-access"
         policy = one(data.aws_iam_policy_document.auth_access.*.json)
-      }
-    ] : [],
-    contains(["node"], local.teleport_node_type) ? [
-      {
-        name   = "teleport-node-access"
-        policy = one(data.aws_iam_policy_document.node_access.*.json)
       }
     ] : [],
     contains(["proxy"], local.teleport_node_type) ? [
@@ -88,8 +86,11 @@ module "node_type_label" {
 # ================================================================= teleport ===
 
 locals {
+  # TLS routing requires auth `proxy_listener_mode: multiplex` and proxy
+  # `version: v2` to agree (gravitational/teleport#57009).
   teleport_config = {
     auth = {
+      version = "v2"
       teleport = {
         nodename     = "$TELEPORT_NODENAME"
         advertise_ip = "$TELEPORT_ADVERTISE_IP"
@@ -109,10 +110,11 @@ locals {
       auth_service = {
         enabled              = "yes"
         cluster_name         = local.dns_name
-        public_addr          = tobool(local.teleport_node_type == "auth") ? "${aws_lb.this[0].dns_name}:3025" : ""
+        public_addr          = local.teleport_public_addr != "" ? "${local.teleport_public_addr}:3025" : ""
         keep_alive_interval  = "1m"
         keep_alive_count_max = 3
         listen_addr          = "0.0.0.0:3025"
+        proxy_listener_mode  = "multiplex"
         authentication = {
           second_factor = "otp"
         }
@@ -125,70 +127,8 @@ locals {
         enabled = "no"
       }
     }
-    node = {
-      teleport = {
-        auth_token   = "/var/lib/teleport/token"
-        ca_pin       = "CA_PIN_HASH_PLACEHOLDER"
-        nodename     = "$TELEPORT_NODENAME"
-        advertise_ip = "$TELEPORT_ADVERTISE_IP"
-        log = {
-          output   = "stderr"
-          severity = "INFO"
-        }
-        data_dir = "/var/lib/teleport"
-        storage = {
-          type = "dir"
-          path = "/var/lib/teleport/backend"
-        }
-        auth_servers = [
-          "${local.dns_name}:443",
-          "${local.teleport_auth_address}:3025",
-        ]
-      }
-      app_service = {
-        enabled   = "yes"
-        debug_app = true
-        resources = [{
-          labels = {
-            "*" : "*"
-          }
-        }]
-      }
-      auth_service = {
-        enabled = "no"
-      }
-      db_service = {
-        enabled = "yes"
-        aws = [{
-          types   = ["rds", "redshift"]
-          regions = [local.aws_region_name]
-          tags = {
-            "*" : "*"
-          }
-        }]
-        resources = [{
-          labels = {
-            "*" : "*"
-          }
-        }]
-      }
-      proxy_service = {
-        enabled = "no"
-      }
-      ssh_service = {
-        enabled     = "yes"
-        listen_addr = "0.0.0.0:3022"
-        enhanced_recording = {
-          enabled             = false # todo enable w/ amazon-linux 2022; minimum supported kernel is 5.8.0
-          command_buffer_size = 8
-          disk_buffer_size    = 128
-          network_buffer_size = 8
-          cgroup_path         = "/cgroup2"
-        }
-        labels = module.this.tags
-      }
-    }
     proxy = {
+      version = "v2"
       teleport = {
         auth_token   = "/var/lib/teleport/token"
         ca_pin       = "CA_PIN_HASH_PLACEHOLDER"
@@ -218,21 +158,17 @@ locals {
         enabled = "no"
       }
       proxy_service = {
-        enabled            = "yes"
-        listen_addr        = "0.0.0.0:3023"
-        tunnel_listen_addr = "0.0.0.0:3080"
-        web_listen_addr    = "0.0.0.0:3080"
-        public_addr        = "${local.dns_name}:443"
-        ssh_public_addr    = "${local.dns_name}:3023"
-        tunnel_public_addr = "${local.dns_name}:443"
+        enabled         = "yes"
+        proxy_protocol  = "on" # paired with proxy_protocol_v2 on the NLB target group
+        web_listen_addr = "0.0.0.0:3080"
+        public_addr     = "${local.dns_name}:443"
         https_keypairs = [{
           cert_file = "/var/lib/teleport/fullchain.pem"
           key_file  = "/var/lib/teleport/privkey.pem"
         }]
         kubernetes = {
           enabled     = "yes"
-          listen_addr = "0.0.0.0:3026"
-          public_addr = ["${local.dns_name}:3026"]
+          public_addr = ["${local.dns_name}:443"]
         }
       }
       ssh_service = {
@@ -310,15 +246,7 @@ resource "aws_autoscaling_group" "this" {
   min_size         = local.min_capacity
   max_size         = local.max_capacity
 
-  target_group_arns = flatten([
-    contains(["auth"], local.teleport_node_type) ? [
-      aws_lb_target_group.auth_ssh[0].arn
-    ] : [],
-    contains(["proxy"], local.teleport_node_type) ? [
-      aws_lb_target_group.proxy_ssh[0].arn,
-      aws_lb_target_group.proxy_web[0].arn,
-    ] : [],
-  ])
+  target_group_arns = local.target_group_arns
 
   enabled_metrics = [
     "GroupMinSize",
@@ -444,107 +372,42 @@ module "security_group" {
   preserve_security_group_id = true
   allow_all_egress           = true
 
-  rules = flatten([
-    [{
-      key                      = "group"
-      type                     = "ingress"
-      from_port                = 0
-      to_port                  = 0
-      protocol                 = "all"
-      description              = "allow all group ingress"
-      cidr_blocks              = []
-      ipv6_cidr_blocks         = []
-      source_security_group_id = null
-      self                     = true
-    }],
-    length(var.vpc_security_group_allowed_cidrs) > 0 ? [{
-      key                      = "auth"
-      type                     = "ingress"
-      from_port                = 3025
-      to_port                  = 3025
-      protocol                 = "tcp"
-      description              = "allow auth traffic"
-      cidr_blocks              = var.vpc_security_group_allowed_cidrs
-      ipv6_cidr_blocks         = []
-      source_security_group_id = null
-      self                     = null
-    }] : [],
-    length(var.vpc_security_group_allowed_cidrs) > 0 ? [{
-      key                      = "node-ssh"
-      type                     = "ingress"
-      from_port                = 3022
-      to_port                  = 3022
-      protocol                 = "tcp"
-      description              = "allow teleport node ssh"
-      cidr_blocks              = var.vpc_security_group_allowed_cidrs
-      ipv6_cidr_blocks         = []
-      source_security_group_id = null
-      self                     = null
-    }] : [],
-    length(var.vpc_security_group_allowed_cidrs) > 0 ? [{
-      key                      = "proxy-ssh"
-      type                     = "ingress"
-      from_port                = 3023
-      to_port                  = 3023
-      protocol                 = "tcp"
-      description              = "allow teleport proxy ssh"
-      cidr_blocks              = var.vpc_security_group_allowed_cidrs
-      ipv6_cidr_blocks         = []
-      source_security_group_id = null
-      self                     = null
-    }] : [],
-    length(var.vpc_security_group_allowed_cidrs) > 0 ? [{
-      key                      = "proxy-reverse-ssh"
-      type                     = "ingress"
-      from_port                = 3024
-      to_port                  = 3024
-      protocol                 = "tcp"
-      description              = "allow teleport proxy reverse-ssh"
-      cidr_blocks              = var.vpc_security_group_allowed_cidrs
-      ipv6_cidr_blocks         = []
-      source_security_group_id = null
-      self                     = null
-    }] : [],
-    length(var.vpc_security_group_allowed_cidrs) > 0 ? [{
-      key                      = "proxy-https"
-      type                     = "ingress"
-      from_port                = 443
-      to_port                  = 443
-      protocol                 = "tcp"
-      description              = "allow teleport proxy https"
-      cidr_blocks              = var.vpc_security_group_allowed_cidrs
-      ipv6_cidr_blocks         = []
-      source_security_group_id = null
-      self                     = null
-    }] : [],
-    length(var.vpc_security_group_allowed_cidrs) > 0 ? [{
-      key                      = "proxy-web"
-      type                     = "ingress"
-      from_port                = 3080
-      to_port                  = 3080
-      protocol                 = "tcp"
-      description              = "allow teleport proxy (alternative) https"
-      cidr_blocks              = var.vpc_security_group_allowed_cidrs
-      ipv6_cidr_blocks         = []
-      source_security_group_id = null
-      self                     = null
-    }] : [],
-    length(var.vpc_security_group_allowed_cidrs) > 0 ? [{
-      key                      = "proxy-mysql"
-      type                     = "ingress"
-      from_port                = 3036
-      to_port                  = 3036
-      protocol                 = "tcp"
-      description              = "allow teleport proxy db connections"
-      cidr_blocks              = var.vpc_security_group_allowed_cidrs
-      ipv6_cidr_blocks         = []
-      source_security_group_id = null
-      self                     = null
-    }] : [],
-  ])
+  rules = [{
+    key                      = "group"
+    type                     = "ingress"
+    from_port                = 0
+    to_port                  = 0
+    protocol                 = "all"
+    description              = "allow all group ingress"
+    cidr_blocks              = []
+    ipv6_cidr_blocks         = []
+    source_security_group_id = null
+    self                     = true
+  }]
 
   tags    = merge(module.node_type_label.tags, { Name = module.node_type_label.id })
   context = module.node_type_label.context
+}
+
+locals {
+  nlb_ingress_ports = local.teleport_node_type == "auth" ? {
+    auth = 3025
+    } : local.teleport_node_type == "proxy" ? {
+    proxy-web = 3080
+  } : {}
+}
+
+# Gate only on module.this.enabled; nlb_security_group_id is known-after-apply
+# and including it in the for_each condition would block plan.
+resource "aws_vpc_security_group_ingress_rule" "from_nlb" {
+  for_each = module.this.enabled ? local.nlb_ingress_ports : {}
+
+  security_group_id            = module.security_group.id
+  description                  = "allow ${each.key} (${each.value}) from nlb"
+  ip_protocol                  = "tcp"
+  from_port                    = each.value
+  to_port                      = each.value
+  referenced_security_group_id = local.nlb_security_group_id
 }
 
 # ---------------------------------------------------------------------- iam ---
@@ -623,7 +486,7 @@ data "aws_iam_policy_document" "ec2_management" {
 }
 
 data "aws_iam_policy_document" "base_access" {
-  count = contains(["auth", "node", "proxy"], local.teleport_node_type) ? 1 : 0
+  count = contains(["auth", "proxy"], local.teleport_node_type) ? 1 : 0
 
   statement {
     sid    = "AllowSecretsKmsKeyAccess"
@@ -674,7 +537,7 @@ data "aws_iam_policy_document" "base_access" {
 }
 
 data "aws_iam_policy_document" "auth_access" {
-  count = module.this.enabled ? 1 : 0
+  count = contains(["auth"], local.teleport_node_type) ? 1 : 0
 
   statement {
     sid    = "AllowSecretsKmsKeyAccess"
@@ -768,42 +631,8 @@ data "aws_iam_policy_document" "auth_access" {
   }
 }
 
-data "aws_iam_policy_document" "node_access" {
-  count = contains(["node"], local.teleport_node_type) ? 1 : 0
-
-  statement {
-    sid    = "AllowDatabaseClusterAccess"
-    effect = "Allow"
-    actions = [
-      "redshift:DescribeClusters",
-      "redshift:GetClusterCredentials",
-      "rds:DescribeDBInstances",
-      "rds:ModifyDBInstance",
-      "rds:DescribeDBClusters",
-      "rds:ModifyDBCluster",
-      "rds-db:connect",
-    ]
-    resources = [
-      "*",
-    ]
-  }
-
-  statement {
-    sid    = "AllowDatabaseIamAccess"
-    effect = "Allow"
-    actions = [
-      "iam:GetRolePolicy",
-      "iam:PutRolePolicy",
-      "iam:DeleteRolePolicy",
-    ]
-    resources = [
-      "*", # todo limit which resources
-    ]
-  }
-}
-
 data "aws_iam_policy_document" "proxy_access" {
-  count = module.this.enabled ? 1 : 0
+  count = contains(["proxy"], local.teleport_node_type) ? 1 : 0
 
   statement {
     sid    = "AllowTeleportS3BucketAccess"
@@ -816,169 +645,5 @@ data "aws_iam_policy_document" "proxy_access" {
       "arn:aws:s3:::${local.teleport_bucket_name}",
       "arn:aws:s3:::${local.teleport_bucket_name}/*",
     ]
-  }
-}
-
-# ====================================================================== nlb ===
-
-module "node_lb_label" {
-  source  = "cloudposse/label/null"
-  version = "0.25.0"
-
-  id_length_limit = 32
-  label_order     = ["name", "attributes"]
-  context         = module.node_type_label.context
-}
-
-resource "aws_lb" "this" {
-  count = contains(["auth", "proxy"], local.teleport_node_type) ? 1 : 0
-
-  name                             = module.node_lb_label.id
-  internal                         = contains(["auth"], local.teleport_node_type)
-  subnets                          = contains(["auth"], local.teleport_node_type) ? local.vpc_private_subnet_ids : local.vpc_public_subnet_ids
-  load_balancer_type               = "network"
-  idle_timeout                     = 3600
-  enable_cross_zone_load_balancing = true
-  enable_deletion_protection       = local.experimental ? false : true
-
-  access_logs {
-    bucket  = local.logs_bucket_name
-    enabled = true
-  }
-
-  tags = module.node_type_label.tags
-}
-
-resource "aws_route53_record" "proxy" {
-  count = contains(["proxy"], local.teleport_node_type) ? 1 : 0
-
-  zone_id         = local.dns_parent_zone_id
-  name            = local.dns_name
-  type            = "A"
-  allow_overwrite = true
-
-  alias {
-    name                   = aws_lb.this[0].dns_name
-    zone_id                = aws_lb.this[0].zone_id
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_route53_record" "proxy_wildcard" {
-  count = contains(["proxy"], local.teleport_node_type) ? 1 : 0
-
-  zone_id         = local.dns_parent_zone_id
-  name            = "*.${local.dns_name}"
-  type            = "A"
-  allow_overwrite = true
-
-  alias {
-    name                   = aws_lb.this[0].dns_name
-    zone_id                = aws_lb.this[0].zone_id
-    evaluate_target_health = true
-  }
-}
-
-# ---------------------------------------------------------------- auth: ssh ---
-
-module "auth_ssh_lb_label" {
-  source  = "cloudposse/label/null"
-  version = "0.25.0"
-
-  # ensure there are room for the 6 unique chars plus dash for actual label
-  attributes      = ["auth", "ssh"]
-  id_length_limit = 32
-  label_order     = ["name", "attributes"]
-  context         = module.node_lb_label.context
-}
-
-resource "aws_lb_target_group" "auth_ssh" {
-  count = contains(["auth"], local.teleport_node_type) ? 1 : 0
-
-  name     = module.node_lb_label.id
-  port     = 3025
-  vpc_id   = local.vpc_id
-  protocol = "TCP"
-}
-
-resource "aws_lb_listener" "auth_ssh" {
-  count = contains(["auth"], local.teleport_node_type) ? 1 : 0
-
-  load_balancer_arn = aws_lb.this[0].arn
-  port              = 3025
-  protocol          = "TCP"
-
-  default_action {
-    target_group_arn = aws_lb_target_group.auth_ssh[0].arn
-    type             = "forward"
-  }
-}
-
-# --------------------------------------------------------------- proxy: ssh ---
-
-module "proxy_ssh_lb_label" {
-  source  = "cloudposse/label/null"
-  version = "0.25.0"
-
-  # ensure there are room for the 6 unique chars plus dash for actual label
-  attributes      = ["proxy", "ssh"]
-  id_length_limit = 32
-  label_order     = ["name", "attributes"]
-  context         = module.node_lb_label.context
-}
-
-resource "aws_lb_target_group" "proxy_ssh" {
-  count = contains(["proxy"], local.teleport_node_type) ? 1 : 0
-
-  name     = module.proxy_ssh_lb_label.id
-  port     = 3023
-  vpc_id   = local.vpc_id
-  protocol = "TCP"
-}
-
-resource "aws_lb_listener" "proxy_ssh" {
-  count = contains(["proxy"], local.teleport_node_type) ? 1 : 0
-
-  load_balancer_arn = aws_lb.this[0].arn
-  port              = 3023
-  protocol          = "TCP"
-
-  default_action {
-    target_group_arn = aws_lb_target_group.proxy_ssh[0].arn
-    type             = "forward"
-  }
-}
-
-# --------------------------------------------------------------- proxy: web ---
-
-module "proxy_web_lb_label" {
-  source  = "cloudposse/label/null"
-  version = "0.25.0"
-
-  attributes      = ["proxy", "web"]
-  id_length_limit = 32
-  label_order     = ["name", "attributes"]
-  context         = module.node_lb_label.context
-}
-
-resource "aws_lb_target_group" "proxy_web" {
-  count = contains(["proxy"], local.teleport_node_type) ? 1 : 0
-
-  name     = module.proxy_web_lb_label.id
-  port     = 3080
-  vpc_id   = local.vpc_id
-  protocol = "TCP"
-}
-
-resource "aws_lb_listener" "proxy_web" {
-  count = contains(["proxy"], local.teleport_node_type) ? 1 : 0
-
-  load_balancer_arn = aws_lb.this[0].arn
-  port              = 443
-  protocol          = "TCP"
-
-  default_action {
-    target_group_arn = aws_lb_target_group.proxy_web[0].arn
-    type             = "forward"
   }
 }

--- a/modules/teleport-node/output.tf
+++ b/modules/teleport-node/output.tf
@@ -1,7 +1,3 @@
-output "lb_dns_name" {
-  value = contains(["auth", "proxy"], local.teleport_node_type) ? aws_lb.this[0].dns_name : ""
-}
-
 output "teleport_dns_name" {
   value = local.dns_name
 }

--- a/modules/teleport-node/variables.tf
+++ b/modules/teleport-node/variables.tf
@@ -33,7 +33,19 @@ variable "teleport_letsencrypt_email" {
 }
 
 variable "teleport_node_type" {
-  type = string
+  type        = string
+  description = "Type of Teleport server this module manages. Only `auth` and `proxy` are supported in v2 (the `node` role was removed)."
+
+  validation {
+    condition     = contains(["auth", "proxy"], var.teleport_node_type)
+    error_message = "teleport_node_type must be one of: auth, proxy."
+  }
+}
+
+variable "teleport_public_addr" {
+  type        = string
+  description = "Public address of the consolidated Teleport NLB. Used to populate `auth_service.public_addr` for the auth role."
+  default     = ""
 }
 
 variable "teleport_security_group_ids" {
@@ -97,11 +109,6 @@ variable "vpc_id" {
   type = string
 }
 
-variable "vpc_security_group_allowed_cidrs" {
-  type    = list(string)
-  default = ["0.0.0.0/0"]
-}
-
 variable "vpc_security_group_ids" {
   type    = list(string)
   default = []
@@ -115,6 +122,19 @@ variable "vpc_private_subnet_ids" {
 variable "vpc_public_subnet_ids" {
   type    = list(string)
   default = []
+}
+
+# ------------------------------------------------------------ load-balancer ---
+
+variable "target_group_arns" {
+  type        = list(string)
+  description = "Target group ARNs the ASG should register instances with. Provided by the consolidated `teleport-nlb` submodule in v2."
+  default     = []
+}
+
+variable "nlb_security_group_id" {
+  type        = string
+  description = "Security group ID of the consolidated NLB. The instance security group accepts ingress from this SG on the Teleport ports relevant to the node type (3025 for auth, 3080 for proxy). Required."
 }
 
 # ---------------------------------------------------------------- component ---

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,12 @@
+# v1 -> v2 state migration. Only the Route53 alias records can be carried
+# over; the LBs, target groups, and node ASG are replaced or destroyed.
+
+moved {
+  from = module.proxy_servers.aws_route53_record.proxy[0]
+  to   = module.teleport_nlb.aws_route53_record.proxy[0]
+}
+
+moved {
+  from = module.proxy_servers.aws_route53_record.proxy_wildcard[0]
+  to   = module.teleport_nlb.aws_route53_record.proxy_wildcard[0]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 # ================================================================= teleport ===
 
 output "teleport_dns_name" {
-  value       = module.auth_servers.teleport_dns_name
+  value       = module.teleport_nlb.teleport_dns_name
   description = "The DNS name of the Teleport service."
 }
 
@@ -10,14 +10,51 @@ output "teleport_auth_config" {
   description = "The configuration details for the Teleport auth service."
 }
 
-output "teleport_node_config" {
-  value       = module.node_servers.teleport_config
-  description = "The configuration details for the Teleport node service."
-}
-
 output "teleport_proxy_config" {
   value       = module.proxy_servers.teleport_config
   description = "The configuration details for the Teleport proxy service."
+}
+
+# ====================================================================== nlb ===
+
+output "teleport_nlb_dns_name" {
+  value       = module.teleport_nlb.nlb_dns_name
+  description = "DNS name of the consolidated Teleport NLB."
+}
+
+output "teleport_nlb_arn" {
+  value       = module.teleport_nlb.nlb_arn
+  description = "ARN of the consolidated Teleport NLB."
+}
+
+output "teleport_nlb_zone_id" {
+  value       = module.teleport_nlb.nlb_zone_id
+  description = "Hosted zone ID of the consolidated Teleport NLB (useful for Route53 alias records)."
+}
+
+output "teleport_nlb_security_group_id" {
+  value       = module.teleport_nlb.security_group_id
+  description = "Security group attached to the consolidated Teleport NLB."
+}
+
+output "teleport_nlb_target_group_arns" {
+  value       = module.teleport_nlb.target_group_arns
+  description = "Map of target group ARNs keyed by listener name."
+}
+
+output "teleport_nlb_vpce_service_name" {
+  value       = module.teleport_nlb.vpce_service_name
+  description = "PrivateLink endpoint service name (for consumers). Empty when PrivateLink is disabled."
+}
+
+output "teleport_nlb_vpce_service_id" {
+  value       = module.teleport_nlb.vpce_service_id
+  description = "PrivateLink endpoint service ID. Empty when PrivateLink is disabled."
+}
+
+output "teleport_nlb_vpce_service_arn" {
+  value       = module.teleport_nlb.vpce_service_arn
+  description = "PrivateLink endpoint service ARN. Empty when PrivateLink is disabled."
 }
 
 # ================================================================ resources ===

--- a/variables.tf
+++ b/variables.tf
@@ -22,39 +22,72 @@ variable "teleport_experimental_mode" {
   default     = false
 }
 
+variable "deletion_protection_enabled" {
+  type        = bool
+  description = "Enable deletion protection on stateful resources (DynamoDB tables and the consolidated NLB). When `null` (the default) the value follows `!teleport_experimental_mode` so non-experimental clusters protect their resources while experimental clusters remain tear-down friendly."
+  default     = null
+  nullable    = true
+}
+
 # ----------------------------------------------------------------- instance ---
 
 variable "instance_config" {
   type = object({
     auth = optional(object({
-      count         = optional(number, 1)
-      sizes         = optional(list(string), ["t3.micro", "t3a.micro"])
-      allowed_cidrs = optional(list(string), ["0.0.0.0/0"])
-      spot = optional(object({
-        enabled             = optional(bool, true)
-        allocation_strategy = optional(string, "capacity-optimized")
-      }), {})
-    }), {})
-    node = optional(object({
-      count         = optional(number, 1)
-      sizes         = optional(list(string), ["t3.micro", "t3a.micro"])
-      allowed_cidrs = optional(list(string), ["0.0.0.0/0"])
+      count = optional(number, 1)
+      sizes = optional(list(string), ["t3.micro", "t3a.micro"])
       spot = optional(object({
         enabled             = optional(bool, true)
         allocation_strategy = optional(string, "capacity-optimized")
       }), {})
     }), {})
     proxy = optional(object({
-      count         = optional(number, 1)
-      sizes         = optional(list(string), ["t3.micro", "t3a.micro"])
-      allowed_cidrs = optional(list(string), ["0.0.0.0/0"])
+      count = optional(number, 1)
+      sizes = optional(list(string), ["t3.micro", "t3a.micro"])
       spot = optional(object({
         enabled             = optional(bool, true)
         allocation_strategy = optional(string, "capacity-optimized")
       }), {})
     }), {})
   })
-  description = "Configuration for the instances. Each type (`auth`, `node`, `proxy`) contains an object with `count`, `sizes`, and `allowed_cidrs`."
+  description = "Configuration for the auth and proxy instance ASGs. The `node` role is no longer supported in v2. Client allow-lists moved from this object to `nlb_allowed_cidrs` on the consolidated NLB."
+  default     = {}
+}
+
+# ====================================================================== nlb ===
+
+variable "nlb_internal" {
+  type        = bool
+  description = "When true (default) the consolidated NLB uses an internal scheme and lives in `vpc_private_subnet_ids`; same-VPC proxy<->auth traffic resolves to private ENI IPs and the cluster SG admits it cleanly. When false the NLB is internet-facing in `vpc_public_subnet_ids` and same-VPC consumers (incl. the proxy reaching auth on :3025) hairpin through the VPC NAT EIPs — populate `nlb_auth_allowed_cidrs` with those EIPs in that scenario. Expose an internal NLB externally via PrivateLink, VPN, or Direct Connect."
+  default     = true
+}
+
+variable "nlb_allowed_cidrs" {
+  type        = list(string)
+  description = "CIDRs allowed to reach the consolidated NLB on the public client port (443)."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "nlb_auth_allowed_cidrs" {
+  type        = list(string)
+  description = "CIDRs allowed to reach the consolidated NLB on the auth listener (3025). Defaults to empty so :3025 stays gated to members of the cluster security group only. Required when `nlb_internal = false` and same-VPC proxies must reach auth via the NLB's public IPs (set to the VPC NAT gateway EIPs)."
+  default     = []
+}
+
+variable "nlb_privatelink_enabled" {
+  type        = bool
+  description = "When true an `aws_vpc_endpoint_service` is created for the consolidated NLB so consumers in other VPCs/accounts can reach Teleport over PrivateLink. Only the public client port (443) is reachable through the endpoint service; auth (3025) remains gated to the cluster security group."
+  default     = false
+}
+
+variable "nlb_privatelink_config" {
+  type = object({
+    acceptance_required = optional(bool, true)
+    allowed_principals  = optional(list(string), [])
+    private_dns_name    = optional(string, "")
+    supported_regions   = optional(list(string), [])
+  })
+  description = "Configuration for the optional PrivateLink endpoint service. `acceptance_required` defaults to true so the provider must approve each consumer endpoint."
   default     = {}
 }
 
@@ -70,14 +103,6 @@ variable "logs_bucket_name" {
   type        = string
   description = "The name of the S3 bucket for logs."
   default     = ""
-}
-
-# ---------------------------------------------------------------------- ddb ---
-
-variable "ddb_deletion_protection_enabled" {
-  type        = bool
-  description = "Toggle deletion protection mode for all DynamoDB tables"
-  default     = true
 }
 
 # ---------------------------------------------------------------------- dns ---
@@ -101,12 +126,23 @@ variable "vpc_id" {
 
 variable "vpc_private_subnet_ids" {
   type        = list(string)
-  description = "The IDs of the private subnets in the VPC to deploy resources into."
+  description = "The IDs of the private subnets in the VPC. Required: hosts the auth/proxy ASGs and the consolidated NLB when `nlb_internal = true` (the default)."
+
+  validation {
+    condition     = length(var.vpc_private_subnet_ids) > 0
+    error_message = "vpc_private_subnet_ids must be non-empty."
+  }
 }
 
 variable "vpc_public_subnet_ids" {
   type        = list(string)
-  description = "The IDs of the public subnets in the VPC to deploy resources into."
+  description = "The IDs of the public subnets in the VPC. Required when `nlb_internal = false`; may be empty when `nlb_internal = true` (the default)."
+  default     = []
+
+  validation {
+    condition     = var.nlb_internal || length(var.vpc_public_subnet_ids) > 0
+    error_message = "vpc_public_subnet_ids must be non-empty when nlb_internal is false."
+  }
 }
 
 # ================================================================== context ===

--- a/version.tf
+++ b/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
# v2.0.0 — Consolidated NLB, TLS routing, PrivateLink

This is a preview of the release notes for `v2.0.0`. v2 is a major rework of the network surface and the Teleport configuration. It targets Teleport 18 and consolidates the previously dedicated auth and proxy NLBs into a single Network Load Balancer running in TLS routing (multiplex) mode.

## Highlights

- **One NLB, two listeners.** Auth (`:3025`) and proxy (`:443` → `:3080`) live on the same NLB. All client protocols — web UI, `tsh ssh`, Kubernetes, every database, reverse tunnels — flow over the proxy's `:443` listener thanks to TLS routing.
- **Defense-in-depth security model.** The NLB has two security groups attached: a dedicated NLB SG that holds the public CIDR ingress rules for `:443` only, and the shared cluster SG that all auth and proxy instances are members of. The cluster SG's self-ingress rule covers proxy ↔ auth on `:3025` without ever opening that port to a CIDR list.
- **Optional AWS PrivateLink.** Flip one flag (`nlb_privatelink_enabled`) and consumers in other VPCs or accounts can reach Teleport over a VPC endpoint service. `enforce_security_group_inbound_rules_on_private_link_traffic = on` plus the SG model above means PrivateLink consumers can only reach `:443`; auth remains gated.
- **Real client IPs preserved.** The `proxy_web` target group sets `proxy_protocol_v2 = true` and the Teleport proxy config carries `proxy_service.proxy_protocol = "on"`, so Teleport's audit log records the real client IP even though the L3 source on the wire is the NLB ENI.
- **Smaller surface area.** The `node` role and its ASG/IAM/SG plumbing are gone. Client allow-lists move from per-role `instance_config.*.allowed_cidrs` to a single `nlb_allowed_cidrs` at the NLB.

## Breaking changes

> Most of these are unavoidable consequences of the consolidation. Pre-existing v1 clusters will see resource replacements on `terraform apply` — plan in a maintenance window.

- **Single consolidated NLB.** The dedicated `auth` and `proxy` NLBs, their target groups and listeners, the per-role label modules, and the LB-related Route53/IAM glue inside `modules/teleport-node` have all been removed. The new NLB lives in `modules/teleport-nlb`. AWS will replace the existing NLB(s) because the scheme/subnets and target group names change. Route53 proxy alias records are migrated in place via `moved {}` blocks and update to point at the new NLB without being destroyed.
- **TLS routing (multiplex) is mandatory.** The proxy is now `version: v2` and only opens `web_listen_addr` (`:3080`, fronted by the NLB on `:443`). The auth advertises `auth_service.proxy_listener_mode: multiplex`. Both halves must agree — see Teleport issue [#57009](https://github.com/gravitational/teleport/issues/57009). Existing clients (`tsh`, reverse tunnel agents, trusted clusters) must reconnect/relogin after the upgrade so they pick up the new routing.
- **`node` role removed.** `module.node_servers`, the `instance_config.node` key, and the `teleport_node_config` output are gone. Pre-existing node ASGs are destroyed on the next `terraform apply`. Pin to `v1.x` or define your own `aws_autoscaling_group` outside this module if you still need that role.
- **`vpc_security_group_allowed_cidrs` and `instance_config.*.allowed_cidrs` removed.** Client allow-lists move to the new `nlb_allowed_cidrs` (a single `list(string)` applied to the public `:443` listener). The internal `:3025` auth listener is reachable only from members of the cluster SG; there is no equivalent CIDR knob for it by design.
- **PROXY protocol enforced.** Connections from the NLB to the proxy carry PROXY protocol v2. Anything bypassing the NLB and hitting the proxy on `:3080` directly will be rejected. This is the trade-off that lets us keep instance ingress SG-only while still preserving the real client IP for the audit log.
- **Outputs.** `teleport_node_config` is gone. `teleport_nlb_dns_name`, `teleport_nlb_arn`, `teleport_nlb_zone_id`, `teleport_nlb_security_group_id`, `teleport_nlb_target_group_arns`, and the three `teleport_nlb_vpce_service_*` outputs are added.

## New inputs

| Name                      | Type           | Default         | Purpose                                                                                                |
| ------------------------- | -------------- | --------------- | ------------------------------------------------------------------------------------------------------ |
| `nlb_internal`            | `bool`         | `false`         | Internal scheme (private subnets) when `true`; internet-facing in public subnets when `false`.         |
| `nlb_allowed_cidrs`       | `list(string)` | `["0.0.0.0/0"]` | CIDRs allowed on the public client port (`:443`). Has no effect on `:3025`.                            |
| `nlb_deletion_protection` | `bool`         | `true`          | Enable deletion protection on the consolidated NLB.                                                    |
| `nlb_privatelink_enabled` | `bool`         | `false`         | Create an `aws_vpc_endpoint_service` on top of the NLB.                                                |
| `nlb_privatelink_config`  | `object`       | `{}`            | `acceptance_required` (default `true`), `allowed_principals`, `private_dns_name`, `supported_regions`. |

`vpc_public_subnet_ids` is now optional — it is required only when `nlb_internal = false`.

## New submodule: `modules/teleport-nlb`

Owns the consolidated NLB end-to-end. Highlights:

- `aws_lb` (NLB) with `security_groups = [dedicated_nlb_sg, cluster_sg]` and `enforce_security_group_inbound_rules_on_private_link_traffic = "on"`.
- Two target groups: `auth_ssh` (`:3025`) and `proxy_web` (`:3080`, `proxy_protocol_v2 = true`).
- Two listeners: `:443` → `proxy_web`, `:3025` → `auth_ssh`.
- Dedicated NLB security group whose only rules are TCP `:443` ingress from each entry in `nlb_allowed_cidrs`.
- Route53 `proxy` and `*.proxy` alias records pointing at the NLB.
- Optional `aws_vpc_endpoint_service` (PrivateLink) when `nlb_privatelink_enabled = true`.
- Outputs: `nlb_dns_name`, `nlb_arn`, `nlb_zone_id`, `security_group_id`, `target_group_arns` (`{auth_ssh, proxy_web}`), `teleport_dns_name`, `vpce_service_name`/`id`/`arn`.

## Migration cheat sheet

```diff
-instance_config = {
-  auth  = { allowed_cidrs = ["10.0.0.0/8"] }
-  proxy = { allowed_cidrs = ["0.0.0.0/0"] }
-  node  = { count = 1 }
-}
+instance_config = {
+  auth  = {}
+  proxy = {}
+}
+
+nlb_allowed_cidrs       = ["0.0.0.0/0"]
+nlb_privatelink_enabled = false
```

After bumping the source version, run `terraform plan` and expect:

- The two v1 NLBs and their target groups/listeners to be **destroyed**.
- One new NLB, two target groups, two listeners, one NLB security group to be **created**.
- The two Route53 alias records to be **updated in place** (via `moved {}` blocks).
- `module.node_servers.*` to be **destroyed**.
- The auth and proxy launch templates to be **updated**; the ASGs will roll instances so the new Teleport config (with `proxy_listener_mode: multiplex` / `version: v2`) is applied.
