### PR TITLE
feat: expose teleport_auth_address override input

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,29 +100,30 @@ other optional variables (e.g., `name`, `tags`, etc.) provided by the
 [documentation](https://registry.terraform.io/modules/cloudposse/label/null/latest)
 for details.
 
-| Name                          | Description                                                                                                | Type           | Default         | Required |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------- | --------------- | :------: |
-| `teleport_runtime_version`    | The runtime version of Teleport (v18 recommended).                                                         | `string`       | n/a             |   yes    |
-| `teleport_letsencrypt_email`  | The email address to use for Let's Encrypt.                                                                | `string`       | n/a             |   yes    |
-| `teleport_setup_mode`         | Toggle Teleport setup mode.                                                                                | `bool`         | `true`          |    no    |
-| `teleport_experimental_mode`  | Toggle Teleport experimental mode.                                                                         | `bool`         | `false`         |    no    |
-| `deletion_protection_enabled` | Enable deletion protection on the NLB and DynamoDB tables. `null` ⇒ follows `!teleport_experimental_mode`. | `bool`         | `null`          |    no    |
-| `instance_config`             | Configuration for the auth and proxy ASGs (`auth`, `proxy` keys with `count`, `sizes`, `spot`).            | `object`       | `{}`            |    no    |
-| `nlb_internal`                | Use an internal NLB (private subnets) instead of internet-facing (public subnets).                         | `bool`         | `true`          |    no    |
-| `nlb_allowed_cidrs`           | CIDRs allowed on the public client port (443) of the NLB.                                                  | `list(string)` | `["0.0.0.0/0"]` |    no    |
-| `nlb_auth_allowed_cidrs`      | CIDRs allowed on the auth listener (3025). Defaults to empty (cluster SG only). See bootstrap notes.       | `list(string)` | `[]`            |    no    |
-| `nlb_privatelink_enabled`     | Expose the NLB as a PrivateLink endpoint service.                                                          | `bool`         | `false`         |    no    |
-| `nlb_privatelink_config`      | PrivateLink config: `acceptance_required`, `allowed_principals`, `private_dns_name`, `supported_regions`.  | `object`       | `{}`            |    no    |
-| `artifacts_bucket_name`       | The name of the S3 bucket for artifacts.                                                                   | `string`       | `""`            |    no    |
-| `logs_bucket_name`            | The name of the S3 bucket for logs.                                                                        | `string`       | `""`            |    no    |
-| `dns_parent_zone_id`          | The ID of the parent DNS zone.                                                                             | `string`       | n/a             |   yes    |
-| `dns_parent_zone_name`        | The name of the parent DNS zone.                                                                           | `string`       | n/a             |   yes    |
-| `vpc_id`                      | The ID of the VPC to deploy resources into.                                                                | `string`       | n/a             |   yes    |
-| `vpc_private_subnet_ids`      | The IDs of the private subnets in the VPC.                                                                 | `list(string)` | n/a             |   yes    |
-| `vpc_public_subnet_ids`       | The IDs of the public subnets. Required when `nlb_internal = false`; may be empty otherwise.               | `list(string)` | `[]`            |    no    |
-| `aws_region_name`             | The name of the AWS region.                                                                                | `string`       | `""`            |    no    |
-| `aws_account_id`              | The ID of the AWS account.                                                                                 | `string`       | `""`            |    no    |
-| `aws_kv_namespace`            | The namespace or prefix for AWS SSM parameters and similar resources.                                      | `string`       | `""`            |    no    |
+| Name                          | Description                                                                                                                           | Type           | Default         | Required |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------- | --------------- | :------: |
+| `teleport_runtime_version`    | The runtime version of Teleport (v18 recommended).                                                                                    | `string`       | n/a             |   yes    |
+| `teleport_letsencrypt_email`  | The email address to use for Let's Encrypt.                                                                                           | `string`       | n/a             |   yes    |
+| `teleport_setup_mode`         | Toggle Teleport setup mode.                                                                                                           | `bool`         | `true`          |    no    |
+| `teleport_experimental_mode`  | Toggle Teleport experimental mode.                                                                                                    | `bool`         | `false`         |    no    |
+| `teleport_auth_address`       | Override the `host[:port]` proxies dial to reach auth. Empty ⇒ cluster FQDN (may be shadowed by PrivateLink private DNS — see notes). | `string`       | `""`            |    no    |
+| `deletion_protection_enabled` | Enable deletion protection on the NLB and DynamoDB tables. `null` ⇒ follows `!teleport_experimental_mode`.                            | `bool`         | `null`          |    no    |
+| `instance_config`             | Configuration for the auth and proxy ASGs (`auth`, `proxy` keys with `count`, `sizes`, `spot`).                                       | `object`       | `{}`            |    no    |
+| `nlb_internal`                | Use an internal NLB (private subnets) instead of internet-facing (public subnets).                                                    | `bool`         | `true`          |    no    |
+| `nlb_allowed_cidrs`           | CIDRs allowed on the public client port (443) of the NLB.                                                                             | `list(string)` | `["0.0.0.0/0"]` |    no    |
+| `nlb_auth_allowed_cidrs`      | CIDRs allowed on the auth listener (3025). Defaults to empty (cluster SG only). See bootstrap notes.                                  | `list(string)` | `[]`            |    no    |
+| `nlb_privatelink_enabled`     | Expose the NLB as a PrivateLink endpoint service.                                                                                     | `bool`         | `false`         |    no    |
+| `nlb_privatelink_config`      | PrivateLink config: `acceptance_required`, `allowed_principals`, `private_dns_name`, `supported_regions`.                             | `object`       | `{}`            |    no    |
+| `artifacts_bucket_name`       | The name of the S3 bucket for artifacts.                                                                                              | `string`       | `""`            |    no    |
+| `logs_bucket_name`            | The name of the S3 bucket for logs.                                                                                                   | `string`       | `""`            |    no    |
+| `dns_parent_zone_id`          | The ID of the parent DNS zone.                                                                                                        | `string`       | n/a             |   yes    |
+| `dns_parent_zone_name`        | The name of the parent DNS zone.                                                                                                      | `string`       | n/a             |   yes    |
+| `vpc_id`                      | The ID of the VPC to deploy resources into.                                                                                           | `string`       | n/a             |   yes    |
+| `vpc_private_subnet_ids`      | The IDs of the private subnets in the VPC.                                                                                            | `list(string)` | n/a             |   yes    |
+| `vpc_public_subnet_ids`       | The IDs of the public subnets. Required when `nlb_internal = false`; may be empty otherwise.                                          | `list(string)` | `[]`            |    no    |
+| `aws_region_name`             | The name of the AWS region.                                                                                                           | `string`       | `""`            |    no    |
+| `aws_account_id`              | The ID of the AWS account.                                                                                                            | `string`       | `""`            |    no    |
+| `aws_kv_namespace`            | The namespace or prefix for AWS SSM parameters and similar resources.                                                                 | `string`       | `""`            |    no    |
 
 ### Outputs
 
@@ -201,6 +202,23 @@ auth. Two ways to resolve it, in order of preference:
    `aws_vpc_endpoint` in the cluster VPC against the module's endpoint service
    and point the proxy at the endpoint DNS instead of the NLB DNS. More moving
    parts; only worth it if you have a wider PrivateLink story.
+
+#### PrivateLink with private DNS in the producer VPC
+
+Enabling `nlb_privatelink_enabled = true` together with
+`nlb_privatelink_config.private_dns_name` registers the cluster FQDN against the
+endpoint service. AWS attaches that private DNS to **every** VPC that hosts a
+consumer endpoint — including the cluster's own producer VPC if a consumer
+endpoint exists there. In that VPC the cluster FQDN now resolves to the
+PrivateLink ENI's private IPs and proxy ⇄ auth `:3025` traffic enters the NLB
+with the PrivateLink ENI IP as its source. With `nlb_internal = false` the NLB's
+security group on `:3025` admits the NAT EIPs, not the PrivateLink ENI IPs, and
+the dials silently time out.
+
+Pass `teleport_auth_address = module.<self>.teleport_nlb_dns_name` (or any other
+address that PrivateLink does not shadow) to keep the proxy → auth path off
+PrivateLink. The raw NLB DNS resolves to the NLB ENIs directly and falls inside
+`nlb_internal`'s SG-only admit rule.
 
 ## Migrating from v1.x to v2
 

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,12 @@ locals {
   teleport_experimental_mode     = var.teleport_experimental_mode
   teleport_aws_account_id        = local.teleport_runtime_version_major >= 15 ? "146628656107" : "126027368216" # gravitational teleport's aws account id for ami filtering - https://goteleport.com/docs/deploy-a-cluster/deployments/aws-starter-cluster-terraform/
 
+  # PrivateLink with private DNS enabled shadows the cluster FQDN inside the
+  # producer VPC, breaking same-VPC proxy -> auth :3025 dials. Callers can
+  # override this to the NLB's raw DNS (or another non-shadowed address) to
+  # keep the auth path off PrivateLink.
+  teleport_auth_address = var.teleport_auth_address != "" ? var.teleport_auth_address : module.teleport_nlb.teleport_dns_name
+
   artifacts_bucket_name = coalesce(var.artifacts_bucket_name, local.teleport_bucket_name)
   logs_bucket_name      = coalesce(var.logs_bucket_name, local.teleport_bucket_name)
   teleport_bucket_name  = module.s3_bucket.bucket_id
@@ -131,7 +137,7 @@ module "proxy_servers" {
   teleport_node_type         = "proxy"
   teleport_setup_mode        = local.teleport_setup_mode
 
-  teleport_auth_address          = module.teleport_nlb.teleport_dns_name
+  teleport_auth_address          = local.teleport_auth_address
   teleport_bucket_name           = module.s3_bucket.bucket_id
   teleport_ddb_table_events_name = aws_dynamodb_table.events[0].name
   teleport_ddb_table_locks_name  = aws_dynamodb_table.locks[0].name

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "teleport_experimental_mode" {
   default     = false
 }
 
+variable "teleport_auth_address" {
+  type        = string
+  description = "Host:port (or host; `:3025` is appended automatically when no port is supplied) the proxy nodes will dial to reach the auth service. Defaults to the cluster's public FQDN (`<dns_label>.<dns_parent_zone_name>`), but that name is shadowed by PrivateLink private DNS in any VPC that hosts a consumer endpoint for this cluster — including the cluster's own producer VPC. Setting this to the NLB's raw DNS name (e.g. `module.<self>.nlb_dns_name`) or an internal address that PrivateLink does not shadow is the recommended override when running the cluster behind PrivateLink with private DNS enabled."
+  default     = ""
+}
+
 variable "deletion_protection_enabled" {
   type        = bool
   description = "Enable deletion protection on stateful resources (DynamoDB tables and the consolidated NLB). When `null` (the default) the value follows `!teleport_experimental_mode` so non-experimental clusters protect their resources while experimental clusters remain tear-down friendly."


### PR DESCRIPTION
## Problem

When `nlb_privatelink_enabled = true` and `nlb_privatelink_config.private_dns_name` is set, AWS attaches the endpoint service's private DNS to **every** VPC that has a consumer endpoint pointed at it — including the cluster's own producer VPC if a consumer endpoint exists there.

In that VPC the cluster FQDN (`<dns_label>.<dns_parent_zone_name>`) now resolves to the PrivateLink ENI's per-AZ private IPs. The proxy nodes (which are configured with `auth_servers = ["${teleport_auth_address}:3025"]`) therefore route their `:3025` traffic through PrivateLink and the consolidated NLB sees the PrivateLink ENI as the source IP, not the NAT EIP / cluster-SG sources that `nlb_auth_allowed_cidrs` and the NLB security group were designed for.

The result is silent timeouts on proxy ⇄ auth heartbeats. Symptom in the browser is `Unable to process SSO callback` for any external auth (the OAuth handshake with the upstream provider succeeds; the proxy then fails to call into auth to validate and the request times out). No obvious failure mode at the OAuth or DNS layer.

Reproduction:

1. Module deployed with `nlb_privatelink_enabled = true`, `nlb_privatelink_config.private_dns_name = "<cluster FQDN>"`, separate auth + proxy ASGs.
2. A `aws_vpc_endpoint` exists in the cluster's own VPC (e.g. for a same-VPC consumer use case, or because the module's own privatelink wiring puts one there).
3. From a proxy node: `dig <cluster FQDN>` returns PrivateLink ENI IPs, not NLB ENI IPs.
4. `journalctl -u teleport-proxy`: `ERRO [WEB] Error while processing callback auth:github ... context deadline exceeded` and `ERRO [PROXY:1] Failed to dial auth ... i/o timeout` for the PrivateLink ENI IPs on `:3025`.

## Change

Adds a new input `teleport_auth_address` that overrides the dial target the proxy module receives:

```hcl
variable "teleport_auth_address" {
  type    = string
  default = ""
}
```

```hcl
# main.tf locals
teleport_auth_address = var.teleport_auth_address != "" ? var.teleport_auth_address : module.teleport_nlb.teleport_dns_name
```

```hcl
# module "proxy_servers"
teleport_auth_address = local.teleport_auth_address
```

Empty (the default) preserves current behaviour — `module.teleport_nlb.teleport_dns_name` (the cluster FQDN). Callers running PrivateLink with private DNS in the producer VPC can set this to the raw NLB hostname (already exposed via `module.<self>.teleport_nlb_dns_name`) to keep the auth path off PrivateLink:

```hcl
module "teleport" {
  source = "..."
  # ...
  teleport_auth_address = module.teleport.teleport_nlb_dns_name
}
```

(Or any other non-shadowed address — e.g. an internal Route53 record under a zone that PrivateLink does not own.)

The raw NLB DNS resolves to the NLB ENIs directly and falls inside `nlb_internal`'s SG-only admit rule (or the public NAT-EIP path for `nlb_internal = false`), so the existing `nlb_auth_allowed_cidrs` semantics keep working unchanged.

## Notes

- Auth nodes don't dial themselves, so only `module.proxy_servers` needs the new value. `module.auth_servers` is unchanged.
- `module.teleport_nlb.nlb_dns_name` already existed; just needed the root-level passthrough (which was also already there as `teleport_nlb_dns_name`). No new outputs.
- README updated under "Reaching the cluster" with a `PrivateLink with private DNS in the producer VPC` subsection plus a variables-table row.
- No state migration; backward compatible.